### PR TITLE
N°5544 Handle new and existing TeemIP attributes

### DIFF
--- a/module.itop-collector-vsphere.php
+++ b/module.itop-collector-vsphere.php
@@ -16,7 +16,7 @@
 
 SetupWebPage::AddModule(
 	__FILE__, // Path to the current file, all other file names are relative to the directory containing this file
-	'itop-collector-vsphere/1.0.13',
+	'itop-collector-vsphere/1.0.14',
 	array(
 		// Identification
 		//

--- a/vSphereIPv4AddressCollector.json
+++ b/vSphereIPv4AddressCollector.json
@@ -90,6 +90,15 @@
 			"friendlyname": "ip"
 		},
 		{
+			"attcode": "ipconfig_id",
+			"update": "1",
+			"reconcile": "0",
+			"update_policy": "master_locked",
+			"reconciliation_attcode": "org_name",
+			"finalclass": "SynchroAttExtKey",
+			"friendlyname": "org_id"
+		},
+		{
 			"attcode": "ip_list",
 			"update": "0",
 			"reconcile": "0",

--- a/vSphereIPv6AddressCollector.class.inc.php
+++ b/vSphereIPv6AddressCollector.class.inc.php
@@ -18,6 +18,7 @@ class vSphereIPv6AddressCollector extends Collector
 {
 	protected $idx;
 	static protected $aIPv6Addresses = null;
+	static protected $sTeemIpVersion;
 
 	public function AttributeIsOptional($sAttCode)
 	{

--- a/vSphereIPv6AddressCollector.json
+++ b/vSphereIPv6AddressCollector.json
@@ -90,6 +90,15 @@
 			"friendlyname": "ip"
 		},
 		{
+			"attcode": "ipconfig_id",
+			"update": "1",
+			"reconcile": "0",
+			"update_policy": "master_locked",
+			"reconciliation_attcode": "org_name",
+			"finalclass": "SynchroAttExtKey",
+			"friendlyname": "org_id"
+		},
+		{
 			"attcode": "ip_list",
 			"update": "0",
 			"reconcile": "0",


### PR DESCRIPTION
VSpherecollector has been adapted to handle "IPAM for iTop". However, it does not handle correctly the additional and optional extension "Network management extended" (teemip-network-mgmt-extended) that may be installed as well. With this extension, following error is reported: 

[2021-08-25 11:17:33] [Error] Failed to update the Synchro Data Source. Inconsistent data model, the attribute 'speed' does not exist in iTop.

This PR corrects that issue.