### PR TITLE
N°1747 - Change VM's CPU attribute to more relevant VMware source

### DIFF
--- a/module.itop-data-collector-vsphere.php
+++ b/module.itop-data-collector-vsphere.php
@@ -16,7 +16,7 @@
 
 SetupWebPage::AddModule(
 	__FILE__, // Path to the current file, all other file names are relative to the directory containing this file
-	'itop-data-collector-vsphere/1.1.0',
+	'itop-data-collector-vsphere/1.1.1-dev',
 	array(
 		// Identification
 		//

--- a/params.distrib.xml
+++ b/params.distrib.xml
@@ -19,7 +19,7 @@
     <default_values type="hash">
       <org_id>$default_org_id$</org_id>
     </default_values>
-    <vsphere_cpu_attribute>numCpuCores</vsphere_cpu_attribute>
+    <cpu_attribute>numCpuCores</cpu_attribute>
   </virtual_machine>
   <os_family_mapping type="array">
     <!-- Syntax /pattern/replacement where:

--- a/params.distrib.xml
+++ b/params.distrib.xml
@@ -19,6 +19,7 @@
     <default_values type="hash">
       <org_id>$default_org_id$</org_id>
     </default_values>
+    <vsphere_cpu_attribute>numCpuCores</vsphere_cpu_attribute>
   </virtual_machine>
   <os_family_mapping type="array">
     <!-- Syntax /pattern/replacement where:

--- a/vSphereHypervisorCollector.class.inc.php
+++ b/vSphereHypervisorCollector.class.inc.php
@@ -107,7 +107,7 @@ class vSphereHypervisorCollector extends ConfigurableCollector
 						'org_id' => $sDefaultOrg,
 						'brand_id' => $oBrandMappings->MapValue($oHypervisor->hardware->systemInfo->vendor, 'Other'),
 						'model_id' => $oModelMappings->MapValue($oHypervisor->hardware->systemInfo->model, ''),
-						'cpu' => $oHypervisor->hardware->cpuInfo->$sVMCPUAttribute) ?? : '',
+						'cpu' => ($oHypervisor->hardware->cpuInfo->$sVMCPUAttribute) ?? '',
 						'ram' => (int)($oHypervisor->hardware->memorySize / (1024*1024)),
 						'osfamily_id' => $oOSFamilyMappings->MapValue($oHypervisor->config->product->name, 'Other'),
 						'osversion_id' => $oOSVersionMappings->MapValue($oHypervisor->config->product->fullName, ''),

--- a/vSphereHypervisorCollector.class.inc.php
+++ b/vSphereHypervisorCollector.class.inc.php
@@ -55,6 +55,11 @@ class vSphereHypervisorCollector extends ConfigurableCollector
 			$sLogin = Utils::GetConfigurationValue('vsphere_login', '');
 			$sPassword = Utils::GetConfigurationValue('vsphere_password', '');
 			$sDefaultOrg = Utils::GetConfigurationValue('default_org_id');
+			$sVMCPUAttribute = 'numCpuCores';
+			$aVMParams = Utils::GetConfigurationValue('virtual_machine', []);
+			if (!empty($aVMParams) && array_key_exists('vsphere_cpu_attribute', $aVMParams) && ($aVMParams['vsphere_cpu_attribute'] != '')) {
+				$sVMCPUAttribute = $aVMParams['vsphere_cpu_attribute'];
+			}
 
 			static::InitVmwarephp();
 			if (!static::CheckSSLConnection($sVSphereServer))
@@ -94,7 +99,7 @@ class vSphereHypervisorCollector extends ConfigurableCollector
 
 				Utils::Log(LOG_DEBUG, "Server {$oHypervisor->name}: {$oHypervisor->hardware->systemInfo->vendor} {$oHypervisor->hardware->systemInfo->model}");
 				Utils::Log(LOG_DEBUG, "Server software: {$oHypervisor->config->product->fullName} - API Version: {$oHypervisor->config->product->apiVersion}");
-				
+
 				$aHypervisorData = array(
 						'id' => $oHypervisor->getReferenceId(),
 				        'primary_key' => $oHypervisor->getReferenceId(),
@@ -102,7 +107,7 @@ class vSphereHypervisorCollector extends ConfigurableCollector
 						'org_id' => $sDefaultOrg,
 						'brand_id' => $oBrandMappings->MapValue($oHypervisor->hardware->systemInfo->vendor, 'Other'),
 						'model_id' => $oModelMappings->MapValue($oHypervisor->hardware->systemInfo->model, ''),
-						'cpu' => $oHypervisor->hardware->cpuInfo->numCpuPackages,
+						'cpu' => $oHypervisor->hardware->cpuInfo->$sVMCPUAttribute,
 						'ram' => (int)($oHypervisor->hardware->memorySize / (1024*1024)),
 						'osfamily_id' => $oOSFamilyMappings->MapValue($oHypervisor->config->product->name, 'Other'),
 						'osversion_id' => $oOSVersionMappings->MapValue($oHypervisor->config->product->fullName, ''),
@@ -110,7 +115,7 @@ class vSphereHypervisorCollector extends ConfigurableCollector
 						'farm_id' => $sFarmName,
 						'server_id' => $oHypervisor->name,
 				);
-				
+
 				foreach(static::GetCustomFields(__CLASS__) as $sAttCode => $sFieldDefinition)
 				{
 				    $aHypervisorData[$sAttCode] = static::GetCustomFieldValue($oHypervisor, $sFieldDefinition);

--- a/vSphereHypervisorCollector.class.inc.php
+++ b/vSphereHypervisorCollector.class.inc.php
@@ -57,8 +57,8 @@ class vSphereHypervisorCollector extends ConfigurableCollector
 			$sDefaultOrg = Utils::GetConfigurationValue('default_org_id');
 			$sVMCPUAttribute = 'numCpuCores';
 			$aVMParams = Utils::GetConfigurationValue('virtual_machine', []);
-			if (!empty($aVMParams) && array_key_exists('vsphere_cpu_attribute', $aVMParams) && ($aVMParams['vsphere_cpu_attribute'] != '')) {
-				$sVMCPUAttribute = $aVMParams['vsphere_cpu_attribute'];
+			if (!empty($aVMParams) && array_key_exists('cpu_attribute', $aVMParams) && ($aVMParams['cpu_attribute'] != '')) {
+				$sVMCPUAttribute = $aVMParams['cpu_attribute'];
 			}
 
 			static::InitVmwarephp();

--- a/vSphereHypervisorCollector.class.inc.php
+++ b/vSphereHypervisorCollector.class.inc.php
@@ -107,7 +107,7 @@ class vSphereHypervisorCollector extends ConfigurableCollector
 						'org_id' => $sDefaultOrg,
 						'brand_id' => $oBrandMappings->MapValue($oHypervisor->hardware->systemInfo->vendor, 'Other'),
 						'model_id' => $oModelMappings->MapValue($oHypervisor->hardware->systemInfo->model, ''),
-						'cpu' => $oHypervisor->hardware->cpuInfo->$sVMCPUAttribute,
+						'cpu' => (isset($oHypervisor->hardware->cpuInfo->$sVMCPUAttribute) ? $oHypervisor->hardware->cpuInfo->$sVMCPUAttribute : ''),
 						'ram' => (int)($oHypervisor->hardware->memorySize / (1024*1024)),
 						'osfamily_id' => $oOSFamilyMappings->MapValue($oHypervisor->config->product->name, 'Other'),
 						'osversion_id' => $oOSVersionMappings->MapValue($oHypervisor->config->product->fullName, ''),

--- a/vSphereHypervisorCollector.class.inc.php
+++ b/vSphereHypervisorCollector.class.inc.php
@@ -107,7 +107,7 @@ class vSphereHypervisorCollector extends ConfigurableCollector
 						'org_id' => $sDefaultOrg,
 						'brand_id' => $oBrandMappings->MapValue($oHypervisor->hardware->systemInfo->vendor, 'Other'),
 						'model_id' => $oModelMappings->MapValue($oHypervisor->hardware->systemInfo->model, ''),
-						'cpu' => (isset($oHypervisor->hardware->cpuInfo->$sVMCPUAttribute) ? $oHypervisor->hardware->cpuInfo->$sVMCPUAttribute : ''),
+						'cpu' => $oHypervisor->hardware->cpuInfo->$sVMCPUAttribute) ?? : '',
 						'ram' => (int)($oHypervisor->hardware->memorySize / (1024*1024)),
 						'osfamily_id' => $oOSFamilyMappings->MapValue($oHypervisor->config->product->name, 'Other'),
 						'osversion_id' => $oOSVersionMappings->MapValue($oHypervisor->config->product->fullName, ''),


### PR DESCRIPTION
On a VM, the number of CPUs was taken, up to now, from the VMWare attribute 'hardware->cpuInfo->numCpuPackages'. However, this attribute corresponds to the number of processors and not the number of cores which would be more relevant for the 'CPU' attribute of an iTop VM. The number of cores is provided by 'hardware->cpuInfo->numCpuCores'.

This PR changes the code so that numCpuCores is used instead of numCpuPackages. At the same time, it provides a coniguration parameter to keep the old behaviour, should that be needed for some customers.
