### PR TITLE
N°6888 - [ER] VSphere collector : manage the case when we do not have access to the network components

### DIFF
--- a/module.itop-data-collector-vsphere.php
+++ b/module.itop-data-collector-vsphere.php
@@ -16,7 +16,7 @@
 
 SetupWebPage::AddModule(
 	__FILE__, // Path to the current file, all other file names are relative to the directory containing this file
-	'itop-data-collector-vsphere/1.1.0',
+	'itop-data-collector-vsphere/1.1.1-dev',
 	array(
 		// Identification
 		//

--- a/vSphereVirtualMachineCollector.class.inc.php
+++ b/vSphereVirtualMachineCollector.class.inc.php
@@ -154,8 +154,8 @@ class vSphereVirtualMachineCollector extends Collector
 
 		utils::Log(LOG_DEBUG, "Collecting network info...");
 		$aNWInterfaces = array();
-		if ($oVirtualMachine->guest->net)
-		{
+		// Make sure user has access to network information - see bug #6888
+		if (isset($oVirtualMachine->guest) && isset($oVirtualMachine->guest->net)) {
 			$aMACToNetwork = array();
 			// The association MACAddress <=> Network is known at the HW level (correspondance between the VirtualINC and its "backing" device)
 			foreach($oVirtualMachine->config->hardware->device as $oVirtualDevice)
@@ -213,6 +213,8 @@ class vSphereVirtualMachineCollector extends Collector
 
 			Utils::Log(LOG_DEBUG, "Collecting IP addresses for this VM...");
 			$aNWInterfaces = static::DoCollectVMIPs($aMACToNetwork, $oVirtualMachine);
+		} else {
+			utils::Log(LOG_DEBUG, "User cannot access to network information of VM ".$oVirtualMachine->name.", skipping.");
 		}
 
 		$aDisks = array();


### PR DESCRIPTION
Customer GLS is connecting to a central vCenter managed by the global IT of his company. For security reasons, access to network information has been denied to him (well, its user)... which is causing a crash of the collector at the step defined by "Collecting network info..." message of the VM collector.

This PR just adds a test to check that network infos are present before trying to process them further.
