### PR TITLE
N°7028 - Add option to only consider the ESX as the VM's virtual host, even if the ESX belongs to a farm

### DIFF
--- a/module.itop-data-collector-vsphere.php
+++ b/module.itop-data-collector-vsphere.php
@@ -16,7 +16,7 @@
 
 SetupWebPage::AddModule(
 	__FILE__, // Path to the current file, all other file names are relative to the directory containing this file
-	'itop-data-collector-vsphere/1.1.0',
+	'itop-data-collector-vsphere/1.1.1-dev',
 	array(
 		// Identification
 		//

--- a/params.distrib.xml
+++ b/params.distrib.xml
@@ -19,6 +19,10 @@
     <default_values type="hash">
       <org_id>$default_org_id$</org_id>
     </default_values>
+    <!-- By default, a VM's virtual host points to the farm that the VM's hypervisor belongs to, if any.
+         This option forces the VM's virtual host to point to the VM's hypervisor
+         Allowed values: hypervisor, farm (default) -->
+    <virtual_host>hypervisor</virtual_host>
   </virtual_machine>
   <os_family_mapping type="array">
     <!-- Syntax /pattern/replacement where:

--- a/vSphereVirtualMachineCollector.class.inc.php
+++ b/vSphereVirtualMachineCollector.class.inc.php
@@ -149,6 +149,11 @@ class vSphereVirtualMachineCollector extends Collector
 		}
 
 		$sDefaultOrg = Utils::GetConfigurationValue('default_org_id');
+		$aVMParams = Utils::GetConfigurationValue('virtual_machine', []);
+		$sVirtualHostType = 'farm';
+		if (array_key_exists('virtual_host', $aVMParams) && $aVMParams['virtual_host'] != '') {
+			$sVirtualHostType = $aVMParams['virtual_host'];
+		}
 		$OSFamily = static::GetOSFamily($oVirtualMachine);
 		$OSVersion = static::GetOSVersion($oVirtualMachine);
 
@@ -229,19 +234,6 @@ class vSphereVirtualMachineCollector extends Collector
 			}
 		}
 
-		$sFarmName = '';
-
-		// Is the hypervisor, on which this VM is running, part of a farm ?
-		utils::Log(LOG_DEBUG, "Checking if the host is part of a Farm...");
-		foreach($aFarms as $aFarm)
-		{
-			if (in_array($oVirtualMachine->runtime->host->name, $aFarm['hosts']))
-			{
-				$sFarmName = $aFarm['name'];
-				break; // Farm found
-			}
-		}
-
 		utils::Log(LOG_DEBUG, "Building VM record...");
 
 		utils::Log(LOG_DEBUG, "Reading Name...");
@@ -268,6 +260,23 @@ class vSphereVirtualMachineCollector extends Collector
 		$sHostName = $oVirtualMachine->runtime->host->name;
 		utils::Log(LOG_DEBUG, "    Host name: $sHostName");
 
+		if ($sVirtualHostType == 'hypervisor') {
+			$sVirtualHost = $sHostName;
+		} else {
+			// Get the farm that the hypervisor, on which this VM is running, is part of, if any
+			utils::Log(LOG_DEBUG, "Checking if the host is part of a Farm...");
+			$sFarmName = '';
+			foreach($aFarms as $aFarm)
+			{
+				if (in_array($oVirtualMachine->runtime->host->name, $aFarm['hosts']))
+				{
+					$sFarmName = $aFarm['name'];
+					break; // Farm found
+				}
+			}
+			$sVirtualHost = empty($sFarmName) ? $sHostName : $sFarmName;
+		}
+
 		return array(
 			'id' => $oVirtualMachine->getReferenceId(),
 			'name' => $sName,
@@ -281,7 +290,7 @@ class vSphereVirtualMachineCollector extends Collector
 			'osversion_id' => $OSVersion,
 			'disks' => $aDisks,
 			'interfaces' => $aNWInterfaces,
-			'virtualhost_id' => empty($sFarmName) ? $sHostName : $sFarmName,
+			'virtualhost_id' => $sVirtualHost,
 			'description' => $sAnnotation,
 		);
 	}


### PR DESCRIPTION
In the vSphere world, an ESX (hypervisor)  belongs to a farm and the ESX that handles a given VM may change over time, though being always attached to the same farm. This behaviour is subject to a VMware option that not all customer may have purchased. Without this option, a given VM is always attached to the same ESX.
 
By default, the vSphere collector sets the farm that the VM's ESX belongs to as the VM's virtual host attribute and set the VM's ESX if that ESX doesn't belong to a farm. In the case described above, it may be more interesting to set the ESX as the VM's virtual host instead of the farm.

This is the purpose of this PR: add a configuration parameter to the vSphere collector so that VM's ESX is set, by default, as VM's virtual host instead of farm.