### PR TITLE
N°7267 - Typo in port detection

### DIFF
--- a/src/vSphereVirtualMachineCollector.class.inc.php
+++ b/src/vSphereVirtualMachineCollector.class.inc.php
@@ -164,7 +164,7 @@ class vSphereVirtualMachineCollector extends vSphereCollector
 										$sNetworkName = $oBacking->deviceName;
 										utils::Log(LOG_DEBUG, "Virtual Network Device: Using ->deviceName: '$sNetworkName'");
 									} else {
-										if (isset($oBacking->portl) && property_exists($oBacking, 'port')) {
+										if (isset($oBacking->port) && property_exists($oBacking, 'port')) {
 											$oPort = $oBacking->port;
 											utils::Log(LOG_DEBUG, "Virtual Network Device '".get_class($oBacking)."': has the following port (".get_class($oPort)."):\n".static::myprint_r($oPort));
 											if (array_key_exists($oPort->portgroupKey, $aVLANs)) {


### PR DESCRIPTION
Fix typo in $oBacking->port 

## Base information
| Question                                                      | Answer 
|---------------------------------------------------------------|--------
| Related to a SourceForge thread / Another PR / Combodo ticket? | No
| Type of change?                                               | Bug fix


## Symptom (bug) / Objective (enhancement)
When collecting information about virtual network devices, there is typo in code which tries to look for property 'portl' instead of 'port'


## Reproduction procedure (bug)

1. With itop-data-collector-vsphere 1.2.0
2. With PHP 8.0.28
3. Targeting iTop-3.0.2-1
4. configure and run datacollector
5. See error:  "Virtual Network Device ... has neither 'network', nor 'opaqueNetworkId', nor 'port'. Dumping the whole object...
6. Expecting correct network detection


## Cause (bug)
Typo in code ($oBacking->portl)

## Proposed solution (bug and enhancement)
Fix typo in  ($oBacking->portl)


## Checklist before requesting a review

- [X] I have performed a self-review of my code, and that it's compliant with [Combodo's guidelines](https://www.itophub.io/wiki/page?id=latest:customization:coding_standards&s[]=convention)
- [X] I have tested all changes I made on an iTop instance
- [x] I have added a unit test, otherwise I have explained why I couldn't (should already exist)
- [X] I have made sure the PR is clear and detailled enough so anyone can understand the real purpose without digging in the code


## Checklist of things to do before PR is ready to merge
- [x] Changes requested in the review