### PR TITLE
Fix ipv4 address detection when TeemIp is used

### DIFF
--- a/src/vSphereIPv4AddressCollector.class.inc.php
+++ b/src/vSphereIPv4AddressCollector.class.inc.php
@@ -67,7 +67,7 @@ class vSphereIPv4AddressCollector extends vSphereCollector
 		if (class_exists('vSphereVirtualMachineCollector')) {
 			$aVMs = vSphereVirtualMachineCollector::CollectVMInfos();
 			foreach ($aVMs as $oVM) {
-				$sIP = filter_var($oVM['managementip'] ?? '', FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) ?: '';
+				$sIP = filter_var($oVM['managementip_id'] ?? '', FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) ?: '';
 				if ($sIP != '') {
 					Utils::Log(LOG_DEBUG, 'IPv4 Address: ' . $sIP);
 					if (in_array('short_name', $oVM)) {


### PR DESCRIPTION
<!--

IMPORTANT: Please follow the guidelines within this PR template before submitting it, it will greatly help us process your PR. 🙏

Any PRs not following the guidelines or with missing information will not be considered.

-->

## Base information
| Question                                                      | Answer 
|---------------------------------------------------------------|--------
| Related to a SourceForge thread / Another PR / Combodo ticket? | No.
| Type of change?                                               | Bug fix


## Symptom (bug) / Objective (enhancement)
Datacollector is not collecting ipv4 addresses for VMs.

If TeemIP is used, the attribute in $oVM object is called 'managementip_id' and not 'managementip'. 



## Reproduction procedure (bug)
1. With itop-data-collector-vsphere 1.4.0
2. With PHP 8.1.3
3. Targeting iTop 3.2.0-2-14758
4. run exec.php in data collector directory (after configuration)
5. see that no ipv4 adress are collected even when should be



## Cause (bug)
wrong attribute used in code


## Proposed solution (bug and enhancement)
Attached patch


## Checklist before requesting a review
<!--
Don't remove these lines, check them once done.
-->
- [X] I have performed a self-review of my code, and that it's compliant with [Combodo's guidelines](https://www.itophub.io/wiki/page?id=latest:customization:coding_standards&s[]=convention)
- [X] I have tested all changes I made on an iTop instance
- [X] I have added a unit test, otherwise I have explained why I couldn't
- [X] I have made sure the PR is clear and detailled enough so anyone can understand the real purpose without digging in the code


## Checklist of things to do before PR is ready to merge
<!--
Things that needs to be done in the PR before it can be considered as ready to be merged

Examples:
- Changes requested in the review
- Unit test to add
- Dictionary entries to translate
- ...
-->

