### PR TITLE
✨ Collect Hypervisor Management IP and Serial Number

### DIFF
--- a/src/vSphereHypervisorCollector.class.inc.php
+++ b/src/vSphereHypervisorCollector.class.inc.php
@@ -94,7 +94,7 @@ class vSphereHypervisorCollector extends vSphereCollector
 				Utils::Log(LOG_DEBUG, "Server software: {$oHypervisor->config->product->fullName} - API Version: {$oHypervisor->config->product->apiVersion}");
 
 				// Hypervisor System Serial Number, as reported by VSphere (Only tested on HPE servers)
-				$sSerialNumber='unknown';
+				$sSerialNumber = '';
 				foreach ($oHypervisor->hardware->systemInfo->otherIdentifyingInfo as $oTstSN)
 				{
 					if ( $oTstSN->identifierType->key == 'ServiceTag' ) { $sSerialNumber = $oTstSN->identifierValue ; }

--- a/src/vSphereHypervisorCollector.class.inc.php
+++ b/src/vSphereHypervisorCollector.class.inc.php
@@ -93,6 +93,22 @@ class vSphereHypervisorCollector extends vSphereCollector
 				Utils::Log(LOG_DEBUG, "Server {$oHypervisor->name}: {$oHypervisor->hardware->systemInfo->vendor} {$oHypervisor->hardware->systemInfo->model}");
 				Utils::Log(LOG_DEBUG, "Server software: {$oHypervisor->config->product->fullName} - API Version: {$oHypervisor->config->product->apiVersion}");
 
+				// Hypervisor System Serial Number, as reported by VSphere (Only tested on HPE servers)
+				$sSerialNumber='unknown';
+				foreach ($oHypervisor->hardware->systemInfo->otherIdentifyingInfo as $oTstSN)
+				{
+					if ( $oTstSN->identifierType->key == 'ServiceTag' ) { $sSerialNumber = $oTstSN->identifierValue ; }
+				}
+				Utils::Log(LOG_DEBUG, "Server serial number: {$sSerialNumber}");
+
+				$sManagementIp='';
+				foreach ($oHypervisor->config->option as $oTstIP)
+				{
+					// First form is probably from an older version of vSphere
+					if ( $oTstIP->key == 'Vpx.Vpxa.config.vpxa.hostIp' || $oTstIP->key == 'Vpx.Vpxa.config.host_ip' ) { $sManagementIp= $oTstIP->value ; }
+				}
+				Utils::Log(LOG_DEBUG, "Server management IP: {$sManagementIp}");
+
 				$aHypervisorData = array(
 					'id' => $oHypervisor->getReferenceId(),
 					'primary_key' => $oHypervisor->getReferenceId(),
@@ -107,6 +123,8 @@ class vSphereHypervisorCollector extends vSphereCollector
 					'status' => 'production',
 					'farm_id' => $sFarmName,
 					'server_id' => $oHypervisor->name,
+					'serialnumber' => $sSerialNumber,
+					'managementip' => $sManagementIp,
 				);
 
 				$oCollectionPlan = vSphereCollectionPlan::GetPlan();

--- a/src/vSphereServerCollector.class.inc.php
+++ b/src/vSphereServerCollector.class.inc.php
@@ -90,6 +90,8 @@ class vSphereServerCollector extends vSphereCollector
 			'osversion_id' => $aHyperV['osversion_id'],
 			'cpu' => $aHyperV['cpu'],
 			'ram' => $aHyperV['ram'],
+			'serialnumber' => $aHyperV['serialnumber'],
+			'managementip' => $aHyperV['managementip'],
 		);
 
 		// Add the custom fields (if any)
@@ -106,12 +108,12 @@ class vSphereServerCollector extends vSphereCollector
 			$bCollectIps = ($aTeemIpOptions['collect_ips'] == 'yes') ? true : false;
 			$bCollectIPv6Addresses = ($aTeemIpOptions['manage_ipv6'] == 'yes') ? true : false;
 
-			$sName = $aHyperV['name'] ?? '';
+			$sCollIP = $aHyperV['managementip'] ?? '';
 			$sIP = '';
 			if ($bCollectIps == 'yes') {
 				// Check if name has IPv4 or "IPv6" format
-				if (filter_var($sName, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) || (($bCollectIPv6Addresses == 'yes') && filter_var($sName, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6))) {
-					$sIP = $sName;
+				if (filter_var($sCollIP, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) || (($bCollectIPv6Addresses == 'yes') && filter_var($sCollIP, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6))) {
+					$sIP = $sCollIP;
 				}
 			}
 


### PR DESCRIPTION


## Base information
| Question                                                      | Answer 
|---------------------------------------------------------------|--------
| Related to a SourceForge thread / Another PR / Combodo ticket? | No
| Type of change?                                               | Enhancement


## Symptom (bug) / Objective (enhancement)

This change collects the Management IP address and te system serial number for Hypervisor.
I was only able to test the Serial Number Collection on HPE Servers, but, as the Serail Numer is reported by the VSphere API, I have good hope that this will work for most supported hardware.


1. With COLLECTOR_NAME 1.4.0-dev
2. With PHP 8.3.17
3. Targeting iTop 3.2.0 and 3.2.1



## Proposed solution (bug and enhancement)

I did in the VSphere API to find some important (for me :)) informations and add them to the other collected stuffs.

Changes were made in vSphereHypervisorCollector.class.inc.php as this is the part collecting informations and in vSphereServerCollector.class.inc.php as those informations are to be added to the server, not the hypervisor.

I didn't have to add anything in the vSphereServerCollector.json as those fields were already expected ?



## Checklist before requesting a review
- [ ] I have performed a self-review of my code, and that it's compliant with [Combodo's guidelines](https://www.itophub.io/wiki/page?id=latest:customization:coding_standards&s[]=convention)
- [X] I have tested all changes I made on an iTop instance
- [ ] I have added a unit test, otherwise I have explained why I couldn't
- [ ] I have made sure the PR is clear and detailled enough so anyone can understand the real purpose without digging in the code


## Checklist of things to do before PR is ready to merge

Well, I think that those changes are "production ready", but now, that's up to you !