### PR TITLE
🐛 change collector submission order

### DIFF
--- a/params.distrib.xml
+++ b/params.distrib.xml
@@ -56,6 +56,18 @@
 		    <enable>yes</enable>
 			<rank>4</rank>
 		</collector>
+		<!-- IPv4 Addresses -->
+		<collector>
+			<name>vSphereIPv4AddressCollector</name>
+		    <enable>yes</enable>
+			<rank>7</rank>
+		</collector>
+		<!-- IPv6 Addresses -->
+		<collector>
+			<name>vSphereIPv6AddressCollector</name>
+		    <enable>yes</enable>
+			<rank>8</rank>
+		</collector>
 		<!-- Farms -->
 		<collector>
 			<name>vSphereFarmCollector</name>
@@ -85,18 +97,6 @@
 			<name>vSphereLogicalInterfaceCollector</name>
 		    <enable>yes</enable>
 			<rank>14</rank>
-		</collector>
-		<!-- IPv4 Addresses -->
-		<collector>
-			<name>vSphereIPv4AddressCollector</name>
-		    <enable>yes</enable>
-			<rank>20</rank>
-		</collector>
-		<!-- IPv6 Addresses -->
-		<collector>
-			<name>vSphereIPv6AddressCollector</name>
-		    <enable>yes</enable>
-			<rank>21</rank>
 		</collector>
 		<!-- Lnks IP Interface to IP Address -->
 		<collector>


### PR DESCRIPTION
## Base information
| Question                                                      | Answer 
|---------------------------------------------------------------|--------
| Related to a SourceForge thread / Another PR / Combodo ticket? | No
| Type of change?                                               | Bug fix


## Symptom (bug) 

This one is a little tricky to catch : The load order in iTop is not optimal, as the IP(v4 and v6) address are loaded after Server and VirtualMachine, but a correct load of Server (with the management ip patch, obviously) and VirtualMachine need that the IP address is already present.

So, at first load of a new VM/Server, the management IP is not present in iTop, hence is not linked as a management IP for the device. Next run of the collector and the trouble is corrected. So in a lab, where the collector runs nearly in an endless loop, you can miss this one. In a production environment, with the collector running mostly once a day, it is more annoying.

## Reproduction procedure (bug)
<!--

1. With COLLECTOR_NAME 1.4.0-dev
2. With PHP 8.3.17
3. Targeting iTop 32.0 and 3.2.1
4. make sure the collector is working fine
5. Create a new VM in the VCenter, with a new IP, make sure that in the VCenter view, the management IP is up (mostly needs that the VMware tools are working)
6. run the collector once, see that the new IP is present (in TeemIP), that the new VM is present (in VirtualMachine) but that the management IP is empty
7. Run the collector once more, and see that the management IP is now set

## Cause (bug)
The default run order of the synchronization is not good : first server, than VM, than IP.

## Proposed solution (bug and enhancement)

I just changed the order in the params.distrib.xml file of the collector. Note that if someone did customize this part in his/her params.local.xml file, this change won't be effective.

## Checklist before requesting a review
- [ ] I have performed a self-review of my code, and that it's compliant with [Combodo's guidelines](https://www.itophub.io/wiki/page?id=latest:customization:coding_standards&s[]=convention)
- [X] I have tested all changes I made on an iTop instance
- [ ] I have added a unit test, otherwise I have explained why I couldn't
- [ ] I have made sure the PR is clear and detailled enough so anyone can understand the real purpose without digging in the code


## Checklist of things to do before PR is ready to merge

Nothing, as this change is really minor.