### PR TITLE
✨ VM logical interface collection again

### DIFF
--- a/src/vSphereLogicalInterfaceCollector.class.inc.php
+++ b/src/vSphereLogicalInterfaceCollector.class.inc.php
@@ -5,9 +5,9 @@ class vSphereLogicalInterfaceCollector extends vSphereCollector
 {
 	protected $idx;
 	protected $oVMLookup;
-    static protected bool $bLogicalInterfacesCollected = false;
+	static protected bool $bLogicalInterfacesCollected = false;
 	static protected array $aLogicalInterfaces = [];
-    static protected bool $bLnkLogicalInterfaceToIPAddressCollected = false;
+	static protected bool $bLnkLogicalInterfaceToIPAddressCollected = false;
 	static protected array $aLnkLogicalInterfaceToIPAddress = [];
 
 	/**
@@ -46,7 +46,7 @@ class vSphereLogicalInterfaceCollector extends vSphereCollector
 	static public function GetLogicalInterfaces()
 	{
 		if (!self::$bLogicalInterfacesCollected) {
-            self::$bLogicalInterfacesCollected = true;
+			self::$bLogicalInterfacesCollected = true;
 			$aVMs = vSphereVirtualMachineCollector::CollectVMInfos();
 
 			$aLogicalInterfaces = array();
@@ -81,14 +81,12 @@ class vSphereLogicalInterfaceCollector extends vSphereCollector
 
 				// As we collect also interfaces without IP, we must check if the IP is not empty
 				// or if 'ip' is not defined
-				if (!isset($aValue['ip']) || empty($aValue['ip'])) {
-					continue;
+				if (isset($aValue['ip']) && !empty($aValue['ip'])) {
+					$aLnkLogicalInterfaceToIPAddress[] = array(
+						'ipinterface_id' => $aValue['macaddress'],
+						'ipaddress_id' => $aValue['ip'],
+					);
 				}
-
-				$aLnkLogicalInterfaceToIPAddress[] = array(
-					'ipinterface_id' => $aValue['macaddress'],
-					'ipaddress_id' => $aValue['ip'],
-				);
 			}
 
 			self::$aLogicalInterfaces = $aFinalLogicalInterfaces;
@@ -101,7 +99,7 @@ class vSphereLogicalInterfaceCollector extends vSphereCollector
 	static public function GetLnks()
 	{
 		if (!self::$bLnkLogicalInterfaceToIPAddressCollected) {
-            self::$bLnkLogicalInterfaceToIPAddressCollected = true;
+			self::$bLnkLogicalInterfaceToIPAddressCollected = true;
 			self::GetLogicalInterfaces();
 		}
 

--- a/src/vSphereLogicalInterfaceCollector.class.inc.php
+++ b/src/vSphereLogicalInterfaceCollector.class.inc.php
@@ -60,7 +60,7 @@ class vSphereLogicalInterfaceCollector extends vSphereCollector
 						'name' => $oInterface['network'],
 						'virtualmachine_orgid' => $oVM['org_id'],
 						'virtualmachine_id' => $oVM['name'],
-						'ip' => $oInterface['ip'],
+						'ip' => $oInterface['ip'] ?? '',
 					);
 				}
 			}
@@ -77,6 +77,12 @@ class vSphereLogicalInterfaceCollector extends vSphereCollector
 						'virtualmachine_orgid' => $aValue['virtualmachine_orgid'],
 						'virtualmachine_id' => $aValue['virtualmachine_id'],
 					);
+				}
+
+				// As we collect also interfaces without IP, we must check if the IP is not empty
+				// or if 'ip' is not defined
+				if (!isset($aValue['ip']) || empty($aValue['ip'])) {
+					continue;
 				}
 
 				$aLnkLogicalInterfaceToIPAddress[] = array(

--- a/src/vSphereLogicalInterfaceCollector.class.inc.php
+++ b/src/vSphereLogicalInterfaceCollector.class.inc.php
@@ -81,7 +81,7 @@ class vSphereLogicalInterfaceCollector extends vSphereCollector
 
 				// As we collect also interfaces without IP, we must check if the IP is not empty
 				// or if 'ip' is not defined
-				if (isset($aValue['ip']) && !empty($aValue['ip'])) {
+				if (!empty($aValue['ip'])) {
 					$aLnkLogicalInterfaceToIPAddress[] = array(
 						'ipinterface_id' => $aValue['macaddress'],
 						'ipaddress_id' => $aValue['ip'],

--- a/src/vSphereServerCollector.class.inc.php
+++ b/src/vSphereServerCollector.class.inc.php
@@ -200,7 +200,12 @@ class vSphereServerCollector extends vSphereCollector
 		$this->oOSVersionLookup->Lookup($aLineData, array('osfamily_id', 'osversion_id'), 'osversion_id', $iLineIndex);
 		$this->oModelLookup->Lookup($aLineData, array('brand_id', 'model_id'), 'model_id', $iLineIndex);
 		if ($this->oCollectionPlan->IsTeemIpInstalled()) {
-			$this->oIPAddressLookup->Lookup($aLineData, array('org_id', 'managementip_id'), 'managementip_id', $iLineIndex);
+			// Empty IP address should not produce a Warning nor an attempt to lookup
+			// To be fair, this should be a choice in the configuration file, but I'm too lazy to do it now (Schirrms 2025-03-04)
+			// Original line (send this kind of messages): [Warning] No mapping found with key: '{ORG_NAME}_', 'managementip_id' will be set to zero.
+			// $this->oIPAddressLookup->Lookup($aLineData, array('org_id', 'managementip_id'), 'managementip_id', $iLineIndex);
+			$bSkipIfEmpty = true;
+			$this->oIPAddressLookup->Lookup($aLineData, array('org_id', 'managementip_id'), 'managementip_id', $iLineIndex, $bSkipIfEmpty);
 		}
 	}
 }

--- a/src/vSphereServerCollector.class.inc.php
+++ b/src/vSphereServerCollector.class.inc.php
@@ -203,9 +203,7 @@ class vSphereServerCollector extends vSphereCollector
 			// Empty IP address should not produce a Warning nor an attempt to lookup
 			// To be fair, this should be a choice in the configuration file, but I'm too lazy to do it now (Schirrms 2025-03-04)
 			// Original line (send this kind of messages): [Warning] No mapping found with key: '{ORG_NAME}_', 'managementip_id' will be set to zero.
-			// $this->oIPAddressLookup->Lookup($aLineData, array('org_id', 'managementip_id'), 'managementip_id', $iLineIndex);
-			$bSkipIfEmpty = true;
-			$this->oIPAddressLookup->Lookup($aLineData, array('org_id', 'managementip_id'), 'managementip_id', $iLineIndex, $bSkipIfEmpty);
+			$this->oIPAddressLookup->Lookup($aLineData, array('org_id', 'managementip_id'), 'managementip_id', $iLineIndex, true);
 		}
 	}
 }

--- a/src/vSphereVirtualMachineCollector.class.inc.php
+++ b/src/vSphereVirtualMachineCollector.class.inc.php
@@ -129,7 +129,7 @@ class vSphereVirtualMachineCollector extends vSphereCollector
 		utils::Log(LOG_DEBUG, "Collecting network info...");
 		$aNWInterfaces = array();
 		// Make sure user has access to network information
-    if (isset($oVirtualMachine->guest->net)) {
+        if (isset($oVirtualMachine->guest->net)) {
 			$aMACToNetwork = array();
 			// Very very light new code to get the network interfaces (see below)
 			$iVirtualInterface = 0;

--- a/src/vSphereVirtualMachineCollector.class.inc.php
+++ b/src/vSphereVirtualMachineCollector.class.inc.php
@@ -562,9 +562,7 @@ class vSphereVirtualMachineCollector extends vSphereCollector
 			// Empty IP address should not produce a Warning nor an attempt to lookup
 			// To be fair, this should be a choice in the configuration file, but I'm too lazy to do it now (Schirrms 2025-03-04)
 			// Original line (send this kind of messages): [Warning] No mapping found with key: '{ORG_NAME}_', 'managementip_id' will be set to zero.
-			// $this->oIPAddressLookup->Lookup($aLineData, array('org_id', 'managementip_id'), 'managementip_id', $iLineIndex);
-			$bSkipIfEmpty = true;
-			$this->oIPAddressLookup->Lookup($aLineData, array('org_id', 'managementip_id'), 'managementip_id', $iLineIndex, $bSkipIfEmpty);
+			$this->oIPAddressLookup->Lookup($aLineData, array('org_id', 'managementip_id'), 'managementip_id', $iLineIndex, true);
 		}
 	}
 }


### PR DESCRIPTION


## Base information
| Question                                                      | Answer 
|---------------------------------------------------------------|--------
| Related to a SourceForge thread / Another PR / Combodo ticket? | no
| Type of change?                                               | Bug fix / Enhancement 


## Symptom (bug) / Objective (enhancement)

I don't know if this is to be seen as a bug, or an enhancment.

If seen as a bug : for as long as I was using the collector (somewhere around version 1.0.11) I never saw the logical intercace of the VMs coming in iTop.
I found another way to collect logical interface, *but this way is not totally accurate* In some case on VMs with a lot of interfaces, some interfaces doesn't show up (more explanations in the comment in the code).

If it's an enhancement

- Collect VM logical interfaces.

## Reproduction procedure (bug)

1. With COLLECTOR_NAME 1.4.0-dev
2. With PHP 8.3.17
3. Targeting iTop 3.2.0 and 3.2.1
4. do a collection
5. check that the logical interface list of the collected Virtual Machine is empty

## Cause (bug)

In my opinion, there is a trouble in the Phpvmware library. The data collected for a VirtualMachine doesn't give informations about the hardware configuration for network interface.
The 'non working part is in this collection:

`foreach ($oVirtualMachine->config->hardware->device as $oVirtualDevice) {`

But, using a somewhat similar request trough the API (I unrestand that the Phpvmware use a Soap protocol) I got the needed information.

(Time to drop this library, use Python and pyvmomi 🙂 - Just a joke!)

## Proposed solution (bug and enhancement)

I collect the interface list on a totally different level, *and this collection, while accurate, is not always complete*. But we are ising that for years now, and the not complete collection only occurs for VM with a lot of different interfaces. Never failed for me on our mono interface VM, and probably not on system with two interfaces. 


## Checklist before requesting a review

- [ ] I have performed a self-review of my code, and that it's compliant with [Combodo's guidelines](https://www.itophub.io/wiki/page?id=latest:customization:coding_standards&s[]=convention)
- [X] I have tested all changes I made on an iTop instance
- [ ] I have added a unit test, otherwise I have explained why I couldn't
- [?] I have made sure the PR is clear and detailled enough so anyone can understand the real purpose without digging in the code


## Checklist of things to do before PR is ready to merge

- [ ] I changed the naming of logical-intefaces (added a number matching the interface number in VMware) I don't know if thiis can brak something (supposing there where interface informations, witch i doubt higly)
- [ ] I also added a change to remove warnings in case of interface without IP. I don't know if this is relevant or not.

