### PR TITLE
✨ More tunable in params files and demi_load_interval

### DIFF
--- a/json/vSphereIPv4AddressCollector.json
+++ b/json/vSphereIPv4AddressCollector.json
@@ -7,7 +7,7 @@
 	"scope_class": "IPv4Address",
 	"database_table_name": "",
 	"scope_restriction": "",
-	"full_load_periodicity": "$full_load_interval$",
+	"full_load_periodicity": "$demi_load_interval$",
 	"reconciliation_policy": "use_attributes",
 	"action_on_zero": "create",
 	"action_on_one": "update",

--- a/json/vSphereIPv6AddressCollector.json
+++ b/json/vSphereIPv6AddressCollector.json
@@ -7,7 +7,7 @@
 	"scope_class": "IPv6Address",
 	"database_table_name": "",
 	"scope_restriction": "",
-	"full_load_periodicity": "$full_load_interval$",
+	"full_load_periodicity": "$demi_load_interval$",
 	"reconciliation_policy": "use_attributes",
 	"action_on_zero": "create",
 	"action_on_one": "update",

--- a/json/vSphereLogicalInterfaceCollector.json
+++ b/json/vSphereLogicalInterfaceCollector.json
@@ -7,7 +7,7 @@
 	"scope_class": "LogicalInterface",
 	"database_table_name": "",
 	"scope_restriction": "",
-	"full_load_periodicity": "$full_load_interval$",
+	"full_load_periodicity": "$demi_load_interval$",
 	"reconciliation_policy": "use_attributes",
 	"action_on_zero": "create",
 	"action_on_one": "update",

--- a/json/vSpherelnkIPInterfaceToIPAddressCollector.json
+++ b/json/vSpherelnkIPInterfaceToIPAddressCollector.json
@@ -7,7 +7,7 @@
 	"scope_class": "lnkIPInterfaceToIPAddress",
 	"database_table_name": "",
 	"scope_restriction": "",
-	"full_load_periodicity": "$full_load_interval$",
+	"full_load_periodicity": "$demi_load_interval$",
 	"reconciliation_policy": "use_attributes",
 	"action_on_zero": "create",
 	"action_on_one": "update",

--- a/params.distrib.xml
+++ b/params.distrib.xml
@@ -130,6 +130,16 @@
 	<json_placeholders type="hash">
 		<prefix>vSphere</prefix>
 		<full_load_interval>604800</full_load_interval><!-- 7 days (in seconds): 7*24*60*60 -->
+		<!-- During VM removal, some troubles in sync because VM are removed beforelogical interfaces and IP Address
+		    So I added a 'demi_load_interval' for 4 sync:
+				vSphereIPv4AddressCollector, vSphereIPv6AddressCollector, vSpherelnkIPInterfaceToIPAddressCollector
+				and vSphereLogicalInterfaceCollector.
+				But it's still ugly (in fact, very dependant of the schedule of the sync). 
+				I think that a more convenient way to solve that would be
+				instead of suppressing in the other synchro at full interval, only to deactivate at full interval, 
+				then suppress after the same interval
+				Schirrms 2025-03-05 -->
+		<demi_load_interval>345600</demi_load_interval><!-- 4 days (in seconds): 4*24*60*60 -->
 		<synchro_status>production</synchro_status>
 	</json_placeholders>
 

--- a/src/ConfigurableCollector.class.inc.php
+++ b/src/ConfigurableCollector.class.inc.php
@@ -42,20 +42,84 @@ abstract class ConfigurableCollector extends Collector
 				foreach ($aSynchroDefinition['attribute_list'] as $idx => $aDef) {
 					$aAttCodeIndex[$aDef['attcode']] = $idx;
 				}
-				foreach ($aCustomSynchro[get_class($this)]['fields'] as $sAttCode => $aFieldsDef) {
-					// Check if the configuration contains an alteration of the JSON
-					if (array_key_exists('json', $aFieldsDef)) {
-						Utils::Log(LOG_INFO, get_class($this)." uses a custom definition for the field $sAttCode of the Synchro Data Source.");
-						// Override the definitions from the JSON by the ones given in the configuration
-						foreach ($aFieldsDef['json'] as $sKey => $sValue) {
-							$idx = $aAttCodeIndex[$sAttCode];
-							$aSynchroDefinition['attribute_list'][$idx][$sKey] = $sValue;
+				if (isset($aCustomSynchro[get_class($this)]['fields']) && is_array($aCustomSynchro[get_class($this)]['fields'])) {
+					foreach ($aCustomSynchro[get_class($this)]['fields'] as $sAttCode => $aFieldsDef) {
+						// Check if the configuration contains an alteration of the JSON
+						if (array_key_exists('json', $aFieldsDef)) {
+							Utils::Log(LOG_INFO, get_class($this)." uses a custom definition for the field $sAttCode of the Synchro Data Source.");
+							// Override the definitions from the JSON by the ones given in the configuration
+							foreach ($aFieldsDef['json'] as $sKey => $sValue) {
+								$idx = $aAttCodeIndex[$sAttCode];
+								$aSynchroDefinition['attribute_list'][$idx][$sKey] = $sValue;
+							}
+						}
+						if (array_key_exists('source', $aFieldsDef)) {
+							Utils::Log(LOG_INFO, get_class($this)." uses a custom collection for the field $sAttCode ({$aFieldsDef['source']}).");
 						}
 					}
-					if (array_key_exists('source', $aFieldsDef)) {
-						Utils::Log(LOG_INFO, get_class($this)." uses a custom collection for the field $sAttCode ({$aFieldsDef['source']}).");
+				}  else {
+					// warn if there is no 'fields' in the class configuration
+					// is this warning necessary?
+					Utils::Log(LOG_DEBUG, "No valid 'fields' array found for class ".get_class($this)." in the custom_synchro configuration.");
+				}
+
+				// general options for this collector
+				// found in my version of the 1.0.16 collector, don't know if this came upstream or if this is
+				// already a custom addition (Schirrms 2025-03-05)
+				// user_delete_policy
+				if (array_key_exists('user_delete_policy', $aCustomSynchro[get_class($this)])) {
+					$sUserDelete = $aCustomSynchro[get_class($this)]['user_delete_policy'];
+					Utils::Log(LOG_INFO, get_class($this)." has a specific user_delete_policy as '$sUserDelete'.");
+					// only possible values : nobody|administrators|everybody
+					if (strpos('nobody|administrators|everybody', $sUserDelete) !== false) {
+						$aSynchroDefinition['user_delete_policy'] = $sUserDelete;
 					}
 				}
+				// delete_policy
+				if (array_key_exists('delete_policy', $aCustomSynchro[get_class($this)])) {
+					$sDelete = $aCustomSynchro[get_class($this)]['delete_policy'];
+					Utils::Log(LOG_INFO, get_class($this)." has a specific delete_policy as '$sDelete'.");
+					// only possible values : ignore|delete|update|update_then_delete
+					if (strpos('ignore|delete|update|update_then_delete', $sDelete) !== false) {
+						$aSynchroDefinition['delete_policy'] = $sDelete;
+					}
+				}
+				// delete_policy_update
+				if (array_key_exists('delete_policy_update', $aCustomSynchro[get_class($this)])) {
+					$sDeleteUpdate = $aCustomSynchro[get_class($this)]['delete_policy_update'];
+					Utils::Log(LOG_INFO, get_class($this)." has a specific delete_policy_update as '$sDeleteUpdate'.");
+					// No real test possible here, but we can check if the value is not empty
+					if (!empty($sDeleteUpdate)) {
+						$aSynchroDefinition['delete_policy_update'] = $sDeleteUpdate;
+					}
+				}
+				// full_load_periodicity (integer value in seconds)
+				if (array_key_exists('full_load_periodicity', $aCustomSynchro[get_class($this)]))	{
+					$sFullLoadPeriodicity = $aCustomSynchro[get_class($this)]['full_load_periodicity'];
+					Utils::Log(LOG_INFO, get_class($this)." has a specific delete_policy_retention as '$sFullLoadPeriodicity'.");
+					// the value must be an integer value (no decimal part)
+					if (is_numeric($sFullLoadPeriodicity) && intval($sFullLoadPeriodicity) == $sFullLoadPeriodicity) {
+						$aSynchroDefinition['full_load_periodicity'] = $sFullLoadPeriodicity;
+					}
+				}
+				// delete_policy_retention (integer value in seconds)
+				if (array_key_exists('delete_policy_retention', $aCustomSynchro[get_class($this)])) {
+					$sDeleteRetention = $aCustomSynchro[get_class($this)]['delete_policy_retention'];
+					Utils::Log(LOG_INFO, get_class($this)." has a specific delete_policy_retention as '$sDeleteRetention'.");
+					// the value must be an integer value (no decimal part)
+					if (is_numeric($sDeleteRetention) && intval($sDeleteRetention) == $sDeleteRetention) {
+						$aSynchroDefinition['delete_policy_retention'] = $sDeleteRetention;
+					}
+				}
+				// Placeholder for custom configuration not yet held by the collector
+				// We have to read all keys in $aCustomSynchro[get_class($this)], and if not in one of the previous cases
+				// we set a warning with the key, the value, and explaining that this key is not yet managed
+				foreach ($aCustomSynchro[get_class($this)] as $sKey => $sValue) {
+					if (!in_array($sKey, array('fields', 'user_delete_policy', 'delete_policy', 'delete_policy_update', 'full_load_periodicity', 'delete_policy_retention'))) {
+						Utils::Log(LOG_WARNING, "The custom value '$sKey' with value '$sValue' is not yet managed for the collector ".get_class($this).".");
+					}
+				}
+
 				// Re-encode back to JSON since we are expected to return the JSON as a string
 				$sSynchroDataSourceDefinition = json_encode($aSynchroDefinition);
 				Utils::Log(LOG_DEBUG, "Custom definition for the Synchro Data Source:\n$sSynchroDataSourceDefinition");


### PR DESCRIPTION

## Base information
| Question                                                      | Answer 
|---------------------------------------------------------------|--------
| Related to a SourceForge thread / Another PR / Combodo ticket? | no
| Type of change?                                               | Enhancement


## Objective (enhancement)

Two parts in this enhancment proposal:

### More tunable values in the 'params.*.xml' file

My goal is to put all customizable values in my params.local.xml file, meaning that a collector upgrade doesn't break my configuration.
In the original tunable to overide values of a json file, it's "only" possible to tune values for params inside attributes_list.
In my old version of the collector (I don't know if this came upstrem or if this is a change I made), I was also able to change the user_delete_policy.

I reported back my change here, and add some other fields that I tune now. I also throw a message if someone put a key not handled now.

### demi_load_interval

With the standard configuration of the collector, all data are removed at the same time in iTop. But this does not work nicely. In fact, what we see as a big job is more a lot of import tasks, done in a precise order to have each required component in iTop before any component linked to. 
So we create VM first, then logical interfaaces that are linked to VM.
But in destruction step, we should remove Logical interface before VM to avoid annoing messages.

That's the reason of the 'demi_load_interval' witch need obviously to be shorter than the full_load_interval.

This solution is not bulletproof (need a good time configuration for the full and the demi interval, matching the collect schedule). Il probably could be possible to have only one delay, but doing a direct suppression for the dependant items, and using udpate_then_delete for the 'main' classes.

But it's working for me!

1. With COLLECTOR_NAME 1.4.0-dev
2. With PHP 8.3.17
3. Targeting iTop 3.2.0 and 3.2.1

## Proposed solution (bug and enhancement)

Added a demi_load_interval in four .json file and in the collector's param.distrib.xml file

Add some logig to be able to parse some other choices from the params.*.xml file to overide values in the .json file

## Checklist before requesting a review

- [ ] I have performed a self-review of my code, and that it's compliant with [Combodo's guidelines](https://www.itophub.io/wiki/page?id=latest:customization:coding_standards&s[]=convention)
- [X] I have tested all changes I made on an iTop instance
- [ ] I have added a unit test, otherwise I have explained why I couldn't
- [ ] I have made sure the PR is clear and detailled enough so anyone can understand the real purpose without digging in the code


## Checklist of things to do before PR is ready to merge

I do think that this change is directly useable.