### PR TITLE
fix: Compatibility with absence of itop-storage-mgmt

### DIFF
--- a/json/vSphereHypervisorCollector.json
+++ b/json/vSphereHypervisorCollector.json
@@ -80,7 +80,7 @@
 		},
 		{
 			"attcode": "logicalvolumes_list",
-			"update": "1",
+			"update": "0",
 			"reconcile": "0",
 			"update_policy": "master_locked",
 			"row_separator": "|",

--- a/json/vSphereVirtualMachineCollector.json
+++ b/json/vSphereVirtualMachineCollector.json
@@ -72,7 +72,7 @@
 		},
 		{
 			"attcode": "logicalvolumes_list",
-			"update": "1",
+			"update": "0",
 			"reconcile": "0",
 			"update_policy": "master_locked",
 			"row_separator": "|",

--- a/src/vSphereFarmCollector.class.inc.php
+++ b/src/vSphereFarmCollector.class.inc.php
@@ -17,6 +17,10 @@ class vSphereFarmCollector extends vSphereCollector
 		// on Servers. Let's safely ignore it.
 		if ($sAttCode == 'providercontracts_list') return true;
 
+		// If the module Advanced Storage Management is not selected, there is no "logicalvolumes_list".
+		// Let's safely ignore it.
+		if ($sAttCode == 'logicalvolumes_list') return true;
+
 		return parent::AttributeIsOptional($sAttCode);
 	}
 	

--- a/src/vSphereHypervisorCollector.class.inc.php
+++ b/src/vSphereHypervisorCollector.class.inc.php
@@ -33,6 +33,10 @@ class vSphereHypervisorCollector extends vSphereCollector
 			if ($sAttCode == 'hostid') return true;
 		}
 
+		// If the module Advanced Storage Management is not selected, there is no "logicalvolumes_list".
+		// Let's safely ignore it.
+		if ($sAttCode == 'logicalvolumes_list') return true;
+
 		return parent::AttributeIsOptional($sAttCode);
 	}
 

--- a/src/vSphereServerCollector.class.inc.php
+++ b/src/vSphereServerCollector.class.inc.php
@@ -46,6 +46,12 @@ class vSphereServerCollector extends vSphereCollector
 		} else {
 			if ($sAttCode == 'hostid') return true;
 		}
+
+		// If the module Advanced Storage Management is not selected, these fields don't exist.
+		// Let's safely ignore them.
+		if ($sAttCode == 'logicalvolumes_list') return true;
+		if ($sAttCode == 'san_list') return true;
+
 		return parent::AttributeIsOptional($sAttCode);
 	}
 

--- a/src/vSphereVirtualMachineCollector.class.inc.php
+++ b/src/vSphereVirtualMachineCollector.class.inc.php
@@ -52,6 +52,10 @@ class vSphereVirtualMachineCollector extends vSphereCollector
 			if ($sAttCode == 'managementip_id') return true;
 		}
 
+		// If the module Advanced Storage Management is not selected, there is no "logicalvolumes_list".
+		// Let's safely ignore it.
+		if ($sAttCode == 'logicalvolumes_list') return true;
+
 		return parent::AttributeIsOptional($sAttCode);
 	}
 


### PR DESCRIPTION
## Base information
| Question                                                      | Answer 
|---------------------------------------------------------------|--------
| Related to a SourceForge thread / Another PR / Combodo ticket? | N/A
| Type of change?                                               | Bug fix

## Symptom

Synchronisation is not possible when **itop-storage-mgmt** module is not installed.

## Reproduction procedure (bug)

1. data-collector-vsphere 1.4.0 
2. With PHP x.y.z <!-- Put complete PHP version (eg. 8.1.24) -->
3. Targeting iTop 3.2.0 without **Advanced Storage Management** enabled
4. Synchro/configure fails

## Cause

The collector doesn't consider `logicalvolumes_list` to be an optional field.

## Proposed solution

Make `logicalvolumes_list` an optional field and also set it to not be updated as none of the collectors add a value for this field.


## Checklist before requesting a review

- [x] I have performed a self-review of my code, and that it's compliant with [Combodo's guidelines](https://www.itophub.io/wiki/page?id=latest:customization:coding_standards&s[]=convention)
- [x] I have tested all changes I made on an iTop instance
- [ ] I have added a unit test, otherwise I have explained why I couldn't
- [x] I have made sure the PR is clear and detailled enough so anyone can understand the real purpose without digging in the code
