### PR TITLE
fix: Compatibility with absence of teemip-network-mgmt-extended

### DIFF
--- a/src/vSphereLogicalInterfaceCollector.class.inc.php
+++ b/src/vSphereLogicalInterfaceCollector.class.inc.php
@@ -15,19 +15,21 @@ class vSphereLogicalInterfaceCollector extends vSphereCollector
 	 */
 	public function AttributeIsOptional($sAttCode)
 	{
-        if ($this->oCollectionPlan->IsTeemIpInstalled()) {
-            if ($sAttCode == 'ipaddress') return true;
-            if ($sAttCode == 'ipgateway') return true;
-            if ($sAttCode == 'ipmask') return true;
-            if ($sAttCode == 'speed') return true;
-        } else {
-            if ($sAttCode == 'interfacespeed_id') return true;
-            if ($sAttCode == 'ip_list') return true;
-            if ($sAttCode == 'layer2protocol_id') return true;
-            if ($sAttCode == 'status') return true;
-            if ($sAttCode == 'vlans_list') return true;
-            if ($sAttCode == 'vrfs_list') return true;
-        }
+		// Regular iTop
+		if ($sAttCode == 'ipaddress') return $this->oCollectionPlan->IsTeemIpInstalled();
+		if ($sAttCode == 'ipgateway') return $this->oCollectionPlan->IsTeemIpInstalled();
+		if ($sAttCode == 'ipmask') return $this->oCollectionPlan->IsTeemIpInstalled();
+		if ($sAttCode == 'speed') return $this->oCollectionPlan->IsTeemIpNMEInstalled();
+
+		// TeemIP Network Management Extended
+		if ($sAttCode == 'interfacespeed_id') return !$this->oCollectionPlan->IsTeemIpNMEInstalled();
+
+		// TeemIP
+		if ($sAttCode == 'ip_list') return !$this->oCollectionPlan->IsTeemIpInstalled();
+		if ($sAttCode == 'layer2protocol_id') return !$this->oCollectionPlan->IsTeemIpNMEInstalled();
+		if ($sAttCode == 'status') return !$this->oCollectionPlan->IsTeemIpInstalled();
+		if ($sAttCode == 'vlans_list') return !$this->oCollectionPlan->IsTeemIpInstalled();
+		if ($sAttCode == 'vrfs_list') return !$this->oCollectionPlan->IsTeemIpInstalled();
 
 		return parent::AttributeIsOptional($sAttCode);
 	}


### PR DESCRIPTION
## Base information
| Question                                                      | Answer 
|---------------------------------------------------------------|--------
| Related to a SourceForge thread / Another PR / Combodo ticket? | N/A
| Type of change?                                               | Bug fix

## Symptom

Synchronisation is not possible when **teemip-core-ip-mgmt** module is installed and  **teemip-network-mgmt-extended** module is not installed.

## Reproduction procedure

1. data-collector-vsphere 1.4.0 
2. With PHP x.y.z <!-- Put complete PHP version (eg. 8.1.24) -->
3. Targeting iTop 3.2.1-1 with **IPAM for iTop** extension
4. Synchro/configure fails

## Cause

The collector wrongly assumed that the `interfacespeed_id` is always present when TeemIP is installed.

## Proposed solution

Check instead if the teemip-network-mgmt-extended module is installed.

## Checklist before requesting a review

- [x] I have performed a self-review of my code, and that it's compliant with [Combodo's guidelines](https://www.itophub.io/wiki/page?id=latest:customization:coding_standards&s[]=convention)
- [x] I have tested all changes I made on an iTop instance
- [ ] I have added a unit test, otherwise I have explained why I couldn't
- [x] I have made sure the PR is clear and detailled enough so anyone can understand the real purpose without digging in the code
